### PR TITLE
Enable per-path config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ before_install:
   - bash ./script/git-version.sh --verbose get
 script:
   - ./build.sh
+
+cache:
+  directories:
+    - $HOME/.dotnet

--- a/Shared.proj
+++ b/Shared.proj
@@ -1,6 +1,17 @@
 <Project>
   <Target Name="SetVersion" BeforeTargets="Build;Pack">
-    <Exec Command="bash '$(MSBuildThisFileDirectory)script/git-version.sh' get" ConsoleToMSBuild="true" StandardOutputImportance="Low">
+    <PropertyGroup>
+      <GitVersionExec><![CDATA[
+        set PATH=/usr/bin;%PATH%
+        sh -c "bash '$(MSBuildThisFileDirectory)script/git-version.sh' get"
+      ]]></GitVersionExec>
+    </PropertyGroup>
+
+    <Exec
+      Command="$(GitVersionExec)"
+      WorkingDirectory="$(MSBuildThisFileDirectory)"
+      ConsoleToMSBuild="true"
+      StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="Version" />
     </Exec>
     <CreateProperty Value="$(Version)">

--- a/script/git-version.sh
+++ b/script/git-version.sh
@@ -366,6 +366,11 @@ while [ $# -ne 0 ]; do
       verbose=true
       ;;
 
+    --dir)
+      pushd "$2" > /dev/null
+      shift
+      ;;
+
     get)
       get-version
       ;;

--- a/src/YoloDev.AspNetCore.Assets/AssetOptions.cs
+++ b/src/YoloDev.AspNetCore.Assets/AssetOptions.cs
@@ -32,19 +32,14 @@ namespace YoloDev.AspNetCore.Assets
     {
       var segments = path.Value.Substring(1).Split('/');
       var dir = path.Value.EndsWith("/");
-      var parentPath = new PathString(string.Join("/", segments.Take(segments.Length - 1)) + (dir ? "/" : ""));
+      var parentPath = new PathString("/" + string.Join("/", segments.Take(segments.Length - 1)) + (dir ? "/" : ""));
       var parent = ForPath(parentPath);
       return new PathOptions(parent);
     }
 
     public PathOptions ForPath(PathString path)
     {
-      if (!path.HasValue)
-      {
-        throw new ArgumentException("Path has no value", nameof(path));
-      }
-
-      if (path == "/")
+      if (!path.HasValue || path == "/")
       {
         return _base;
       }

--- a/src/YoloDev.AspNetCore.Assets/AssetOptions.cs
+++ b/src/YoloDev.AspNetCore.Assets/AssetOptions.cs
@@ -1,7 +1,64 @@
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using YoloDev.AspNetCore.Assets.Options;
+
 namespace YoloDev.AspNetCore.Assets
 {
-  public class AssetOptions
+  public class AssetOptions : IPathOptions
   {
-    public bool UseDevelopmentAssets { get; set; }
+    private readonly PathOptions _base;
+    private ImmutableDictionary<PathString, PathOptions> _options = ImmutableDictionary.Create<PathString, PathOptions>();
+
+    public bool UseDevelopmentAssets {
+      get => _base.UseDevelopmentAssets;
+      set => _base.UseDevelopmentAssets = value;
+    }
+
+    public string DevServer {
+      get => _base.DevServer;
+      set => _base.DevServer = value;
+    }
+
+    public AssetOptions() : this(PathOptions.Default()) { }
+
+    internal AssetOptions(PathOptions baseOptions)
+    {
+      _base = baseOptions;
+    }
+
+    private PathOptions CreatePathOptions(PathString path)
+    {
+      var segments = path.Value.Substring(1).Split('/');
+      var dir = path.Value.EndsWith("/");
+      var parentPath = new PathString(string.Join("/", segments.Take(segments.Length - 1)) + (dir ? "/" : ""));
+      var parent = ForPath(parentPath);
+      return new PathOptions(parent);
+    }
+
+    public PathOptions ForPath(PathString path)
+    {
+      if (!path.HasValue)
+      {
+        throw new ArgumentException("Path has no value", nameof(path));
+      }
+
+      if (path == "/")
+      {
+        return _base;
+      }
+
+      return ImmutableInterlocked.GetOrAdd(ref _options, path, CreatePathOptions);
+    }
+
+    public IPathOptions Set(
+      Optional<bool> useDevelopmentAssets = default(Optional<bool>),
+      Optional<string> devServer = default(Optional<string>))
+    {
+      _base.Set(useDevelopmentAssets, devServer);
+
+      return this;
+    }
   }
 }

--- a/src/YoloDev.AspNetCore.Assets/AssetOptions.cs
+++ b/src/YoloDev.AspNetCore.Assets/AssetOptions.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Http;
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using YoloDev.AspNetCore.Assets.Options;
@@ -16,10 +15,10 @@ namespace YoloDev.AspNetCore.Assets
       set => _base.UseDevelopmentAssets = value;
     }
 
-    public string DevServer {
-      get => _base.DevServer;
-      set => _base.DevServer = value;
-    }
+    //public string DevServer {
+    //  get => _base.DevServer;
+    //  set => _base.DevServer = value;
+    //}
 
     public AssetOptions() : this(PathOptions.Default()) { }
 
@@ -48,10 +47,10 @@ namespace YoloDev.AspNetCore.Assets
     }
 
     public IPathOptions Set(
-      Optional<bool> useDevelopmentAssets = default(Optional<bool>),
-      Optional<string> devServer = default(Optional<string>))
+      Optional<bool> useDevelopmentAssets = default(Optional<bool>)/*,
+      Optional<string> devServer = default(Optional<string>)*/)
     {
-      _base.Set(useDevelopmentAssets, devServer);
+      _base.Set(useDevelopmentAssets/*, devServer*/);
 
       return this;
     }

--- a/src/YoloDev.AspNetCore.Assets/AssetService.cs
+++ b/src/YoloDev.AspNetCore.Assets/AssetService.cs
@@ -32,7 +32,7 @@ namespace YoloDev.AspNetCore.Assets
         throw new ArgumentException("Path cannot be empty", nameof(path));
       }
 
-      if (_options.Value.UseDevelopmentAssets)
+      if (_options.Value.ForPath(path).UseDevelopmentAssets)
       {
         return GetBasePath(context).Add(path);
       }

--- a/src/YoloDev.AspNetCore.Assets/Options/DelegatedValue.cs
+++ b/src/YoloDev.AspNetCore.Assets/Options/DelegatedValue.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace YoloDev.AspNetCore.Assets.Options
+{
+  public class DelegatedValue<T>
+  {
+    private readonly DelegatedValue<T> _parent;
+    private readonly T _value;
+
+    internal DelegatedValue(DelegatedValue<T> parent)
+    {
+      _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+      _value = default(T);
+    }
+
+    private DelegatedValue(T value)
+    {
+      _parent = null;
+      _value = value;
+    }
+
+    public bool IsSet => _parent == null;
+    public T Value => _parent == null ? _value : _parent.Value;
+
+    public static implicit operator T(DelegatedValue<T> delegatedValue) => delegatedValue.Value;
+    public static implicit operator DelegatedValue<T>(T value) => new DelegatedValue<T>(value);
+  }
+}

--- a/src/YoloDev.AspNetCore.Assets/Options/IPathOptions.cs
+++ b/src/YoloDev.AspNetCore.Assets/Options/IPathOptions.cs
@@ -3,10 +3,10 @@ namespace YoloDev.AspNetCore.Assets.Options
   public interface IPathOptions
   {
     bool UseDevelopmentAssets { get; set; }
-    string DevServer { get; set; }
+    //string DevServer { get; set; }
 
     IPathOptions Set(
-      Optional<bool> useDevelopmentAssets = default(Optional<bool>),
-      Optional<string> devServer = default(Optional<string>));
+      Optional<bool> useDevelopmentAssets = default(Optional<bool>)//,
+      /*Optional<string> devServer = default(Optional<string>)*/);
   }
 }

--- a/src/YoloDev.AspNetCore.Assets/Options/IPathOptions.cs
+++ b/src/YoloDev.AspNetCore.Assets/Options/IPathOptions.cs
@@ -1,0 +1,12 @@
+namespace YoloDev.AspNetCore.Assets.Options
+{
+  public interface IPathOptions
+  {
+    bool UseDevelopmentAssets { get; set; }
+    string DevServer { get; set; }
+
+    IPathOptions Set(
+      Optional<bool> useDevelopmentAssets = default(Optional<bool>),
+      Optional<string> devServer = default(Optional<string>));
+  }
+}

--- a/src/YoloDev.AspNetCore.Assets/Options/Optional.cs
+++ b/src/YoloDev.AspNetCore.Assets/Options/Optional.cs
@@ -1,0 +1,24 @@
+namespace YoloDev.AspNetCore.Assets.Options
+{
+  public struct Optional<T>
+  {
+    private readonly bool _hasValue;
+    private readonly T _value;
+
+    private Optional(T value)
+    {
+      _hasValue = true;
+      _value = value;
+    }
+
+    internal void Set(ref DelegatedValue<T> delegatedValue)
+    {
+      if (_hasValue)
+      {
+        delegatedValue = _value;
+      }
+    }
+
+    public static implicit operator Optional<T>(T value) => new Optional<T>(value);
+  }
+}

--- a/src/YoloDev.AspNetCore.Assets/Options/PathOptions.cs
+++ b/src/YoloDev.AspNetCore.Assets/Options/PathOptions.cs
@@ -3,11 +3,11 @@ namespace YoloDev.AspNetCore.Assets.Options
   public class PathOptions : IPathOptions
   {
     public static PathOptions Default() => new PathOptions(
-      useDevelopmentAssets: false,
-      devServer: null);
+      useDevelopmentAssets: false/*,
+      devServer: null*/);
 
     private DelegatedValue<bool> _useDevelopmentAssets;
-    private DelegatedValue<string> _devServer;
+    //private DelegatedValue<string> _devServer;
 
     public bool UseDevelopmentAssets
     {
@@ -15,34 +15,34 @@ namespace YoloDev.AspNetCore.Assets.Options
       set => _useDevelopmentAssets = value;
     }
 
-    public string DevServer
-    {
-      get => _devServer;
-      set => _devServer = value;
-    }
+    //public string DevServer
+    //{
+    //  get => _devServer;
+    //  set => _devServer = value;
+    //}
 
     public IPathOptions Set(
-      Optional<bool> useDevelopmentAssets = default(Optional<bool>),
-      Optional<string> devServer = default(Optional<string>))
+      Optional<bool> useDevelopmentAssets = default(Optional<bool>)/*,
+      Optional<string> devServer = default(Optional<string>)*/)
     {
       useDevelopmentAssets.Set(ref _useDevelopmentAssets);
-      devServer.Set(ref _devServer);
+      //devServer.Set(ref _devServer);
 
       return this;
     }
 
     private PathOptions(
-      bool useDevelopmentAssets,
-      string devServer)
+      bool useDevelopmentAssets/*,
+      string devServer*/)
     {
       _useDevelopmentAssets = useDevelopmentAssets;
-      _devServer = devServer;
+      //_devServer = devServer;
     }
 
     internal PathOptions(PathOptions parent)
     {
       _useDevelopmentAssets = new DelegatedValue<bool>(parent._useDevelopmentAssets);
-      _devServer = new DelegatedValue<string>(parent._devServer);
+      //_devServer = new DelegatedValue<string>(parent._devServer);
     }
   }
 }

--- a/src/YoloDev.AspNetCore.Assets/Options/PathOptions.cs
+++ b/src/YoloDev.AspNetCore.Assets/Options/PathOptions.cs
@@ -3,7 +3,7 @@ namespace YoloDev.AspNetCore.Assets.Options
   public class PathOptions : IPathOptions
   {
     public static PathOptions Default() => new PathOptions(
-      useDevelopmentAssets: true,
+      useDevelopmentAssets: false,
       devServer: null);
 
     private DelegatedValue<bool> _useDevelopmentAssets;

--- a/src/YoloDev.AspNetCore.Assets/Options/PathOptions.cs
+++ b/src/YoloDev.AspNetCore.Assets/Options/PathOptions.cs
@@ -1,0 +1,48 @@
+namespace YoloDev.AspNetCore.Assets.Options
+{
+  public class PathOptions : IPathOptions
+  {
+    public static PathOptions Default() => new PathOptions(
+      useDevelopmentAssets: true,
+      devServer: null);
+
+    private DelegatedValue<bool> _useDevelopmentAssets;
+    private DelegatedValue<string> _devServer;
+
+    public bool UseDevelopmentAssets
+    {
+      get => _useDevelopmentAssets;
+      set => _useDevelopmentAssets = value;
+    }
+
+    public string DevServer
+    {
+      get => _devServer;
+      set => _devServer = value;
+    }
+
+    public IPathOptions Set(
+      Optional<bool> useDevelopmentAssets = default(Optional<bool>),
+      Optional<string> devServer = default(Optional<string>))
+    {
+      useDevelopmentAssets.Set(ref _useDevelopmentAssets);
+      devServer.Set(ref _devServer);
+
+      return this;
+    }
+
+    private PathOptions(
+      bool useDevelopmentAssets,
+      string devServer)
+    {
+      _useDevelopmentAssets = useDevelopmentAssets;
+      _devServer = devServer;
+    }
+
+    internal PathOptions(PathOptions parent)
+    {
+      _useDevelopmentAssets = new DelegatedValue<bool>(parent._useDevelopmentAssets);
+      _devServer = new DelegatedValue<string>(parent._devServer);
+    }
+  }
+}

--- a/src/YoloDev.AspNetCore.Assets/YoloDev.AspNetCore.Assets.csproj
+++ b/src/YoloDev.AspNetCore.Assets/YoloDev.AspNetCore.Assets.csproj
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Shared.proj" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="1.1.2"/>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2"/>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3"/>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1"/>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.3"/>
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Enables setting config options per path. Options are inherited from parent directories.